### PR TITLE
Improved external pointing device support (USB/BT mouse, stylus)

### DIFF
--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
@@ -412,6 +412,16 @@ public class GamePlay extends AppCompatActivity implements OnSharedPreferenceCha
 	}
 
 	@Override
+	public boolean dispatchKeyEvent(@NonNull KeyEvent event) {
+		int keyCode = event.getKeyCode();
+		// Only delegate for MENU key, delegating for other keys might break something(?)
+		if (progress == null && keyCode == KeyEvent.KEYCODE_MENU && gameView.dispatchKeyEvent(event)) {
+			return true;
+		}
+		return super.dispatchKeyEvent(event);
+	}
+
+	@Override
 	protected void onNewIntent(Intent intent)
 	{
 		if( progress != null ) {

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
@@ -113,6 +113,8 @@ public class GamePlay extends AppCompatActivity implements OnSharedPreferenceCha
 	private static final String STAY_AWAKE_KEY = "stayAwake";
 	private static final String UNDO_REDO_KBD_KEY = "undoRedoOnKeyboard";
 	private static final boolean UNDO_REDO_KBD_DEFAULT = true;
+	static final String MOUSE_LONG_PRESS_KEY = "extMouseLongPress";
+	private static final String MOUSE_BACK_KEY = "extMouseBackKey";
 	private static final String PATTERN_SHOW_LENGTHS_KEY = "patternShowLengths";
 	private static final String COMPLETED_PROMPT_KEY = "completedPrompt";
 	private static final String CONTROLS_REMINDERS_KEY = "controlsReminders";
@@ -344,6 +346,8 @@ public class GamePlay extends AppCompatActivity implements OnSharedPreferenceCha
 		if (prefs.getBoolean(KEYBOARD_BORDERS_KEY, false)) {
 			applyKeyboardBorders();
 		}
+		applyMouseLongPress();
+		applyMouseBackKey();
 		refreshStatusBarColours();
 		getWindow().setBackgroundDrawable(null);
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
@@ -1846,7 +1850,21 @@ public class GamePlay extends AppCompatActivity implements OnSharedPreferenceCha
 			applyKeyboardBorders();
 		} else if (key.equals(BRIDGES_SHOW_H_KEY) || key.equals(UNEQUAL_SHOW_H_KEY)) {
 			applyShowH();
+		} else if (key.equals(MOUSE_LONG_PRESS_KEY)) {
+			applyMouseLongPress();
+		} else if (key.equals(MOUSE_BACK_KEY)) {
+			applyMouseBackKey();
 		}
+	}
+
+	private void applyMouseLongPress() {
+		final String pref = prefs.getString(MOUSE_LONG_PRESS_KEY, "auto");
+		gameView.alwaysLongPress = "always".equals(pref);
+		gameView.hasRightMouse = "never".equals(pref);
+	}
+
+	private void applyMouseBackKey() {
+		gameView.mouseBackSupport = prefs.getBoolean(MOUSE_BACK_KEY, true);
 	}
 
 	private void applyKeyboardBorders() {

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
@@ -31,6 +31,7 @@ import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.HapticFeedbackConstants;
+import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
@@ -60,7 +61,9 @@ public class GameView extends View
 	private int button;
 	private int backgroundColour;
 	private boolean waitingSpace = false;
+	private boolean rightMouseHeld = false;
 	private PointF touchStart;
+	private PointF mousePos;
 	private final double maxDistSq;
 	private static final int LEFT_BUTTON = 0x0200;
 	private static final int MIDDLE_BUTTON = 0x201;
@@ -144,9 +147,19 @@ public class GameView extends View
 					button = LEFT_BUTTON;
 				}
 				touchStart = pointFromEvent(event);
-				touchState = TouchState.WAITING_LONG_PRESS;
 				parent.handler.removeCallbacks(sendLongPress);
-				parent.handler.postDelayed(sendLongPress, longPressTimeout);
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD &&
+						event.getSource() == InputDevice.SOURCE_MOUSE) {
+					parent.sendKey(viewToGame(touchStart), button);
+					if (dragMode == DragMode.PREVENT) {
+						touchState = TouchState.IDLE;
+					} else {
+						touchState = TouchState.DRAGGING;
+					}
+				} else {
+					touchState = TouchState.WAITING_LONG_PRESS;
+					parent.handler.postDelayed(sendLongPress, longPressTimeout);
+				}
 				return true;
 			}
 
@@ -422,11 +435,34 @@ public class GameView extends View
 	};
 
 	@Override
+	public boolean onGenericMotionEvent(@NonNull MotionEvent event)
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD &&
+				event.getSource() == InputDevice.SOURCE_MOUSE) {
+			switch (event.getActionMasked()) {
+				case MotionEvent.ACTION_HOVER_MOVE:
+					mousePos = pointFromEvent(event);
+					if (rightMouseHeld && touchState == TouchState.DRAGGING) {
+						event.setAction(MotionEvent.ACTION_MOVE);
+						return handleTouchEvent(event, false);
+					}
+					break;
+			}
+		}
+		return super.onGenericMotionEvent(event);
+	}
+
+	@Override
 	public boolean onTouchEvent(@NonNull MotionEvent event)
 	{
 		if (parent.currentBackend == null) return false;
 		boolean sdRet = hasPinchZoom && checkPinchZoom(event);
 		boolean gdRet = gestureDetector.onTouchEvent(event);
+		return handleTouchEvent(event, sdRet || gdRet);
+	}
+
+	private boolean handleTouchEvent(@NonNull MotionEvent event, boolean sdgdRet)
+	{
 		lastTouch = pointFromEvent(event);
 		if (event.getAction() == MotionEvent.ACTION_UP) {
 			parent.handler.removeCallbacks(sendLongPress);
@@ -445,7 +481,7 @@ public class GameView extends View
 		} else if (event.getAction() == MotionEvent.ACTION_MOVE) {
 			// 2nd clause is 2 fingers a constant distance apart
 			if ((hasPinchZoom && isScaleInProgress()) || event.getPointerCount() > 1) {
-				return sdRet || gdRet;
+				return sdgdRet;
 			}
 			float x = event.getX(), y = event.getY();
 			if (touchState == TouchState.WAITING_LONG_PRESS && movedPastTouchSlop(x, y)) {
@@ -464,7 +500,7 @@ public class GameView extends View
 			}
 			return false;
 		} else {
-			return sdRet || gdRet;
+			return sdgdRet;
 		}
 	}
 
@@ -503,6 +539,25 @@ public class GameView extends View
 		case KeyEvent.KEYCODE_BUTTON_L1: key = 'U'; break;
 		case KeyEvent.KEYCODE_BUTTON_R1: key = 'R'; break;
 		case KeyEvent.KEYCODE_DEL: key = '\b'; break;
+		// Mouse right-click = BACK auto-repeats on at least Galaxy S7
+		case KeyEvent.KEYCODE_BACK:
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD &&
+					event.getSource() == InputDevice.SOURCE_MOUSE) {
+				if (rightMouseHeld) {
+					return true;
+				}
+				rightMouseHeld = true;
+				touchStart = mousePos;
+				button = RIGHT_BUTTON;
+				parent.sendKey(viewToGame(touchStart), button);
+				if (dragMode == DragMode.PREVENT) {
+					touchState = TouchState.IDLE;
+				} else {
+					touchState = TouchState.DRAGGING;
+				}
+				return true;
+			}
+			break;
 		}
 		if (key == CURSOR_UP || key == CURSOR_DOWN || key == CURSOR_LEFT || key == CURSOR_RIGHT) {
 			// "only apply to cursor keys"
@@ -533,11 +588,32 @@ public class GameView extends View
 	@Override
 	public boolean onKeyUp( int keyCode, KeyEvent event )
 	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD &&
+				event.getSource() == InputDevice.SOURCE_MOUSE) {
+			if (keyCode == KeyEvent.KEYCODE_BACK && rightMouseHeld) {
+				rightMouseHeld = false;
+				if (touchState == TouchState.DRAGGING) {
+					parent.sendKey(viewToGame(mousePos), button + RELEASE);
+				}
+				touchState = TouchState.IDLE;
+			}
+			return true;
+		}
 		if (keyCode != KeyEvent.KEYCODE_DPAD_CENTER || ! waitingSpace)
 			return super.onKeyUp(keyCode, event);
 		parent.handler.removeCallbacks(sendSpace);
 		parent.sendKey(0, 0, '\n');
 		return true;
+	}
+
+	@Override
+	public boolean dispatchKeyEvent(@NonNull KeyEvent event) {
+		int keyCode = event.getKeyCode();
+		// Mouse right-click-and-hold sends MENU as a "keyboard" on at least Galaxy S7, ignore
+		if (keyCode == KeyEvent.KEYCODE_MENU && rightMouseHeld) {
+			return true;
+		}
+		return super.dispatchKeyEvent(event);
 	}
 
 	@Override

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/PrefsActivity.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/PrefsActivity.java
@@ -68,6 +68,7 @@ public class PrefsActivity extends PreferenceActivity implements OnSharedPrefere
 		updateSummary((ListPreference) findPreference(GamePlay.ORIENTATION_KEY));
 		updateSummary((ListPreference) findPreference(NightModeHelper.NIGHT_MODE_KEY));
 		updateSummary((ListPreference) findPreference(GamePlay.LIMIT_DPI_KEY));
+		updateSummary((ListPreference) findPreference(GamePlay.MOUSE_LONG_PRESS_KEY));
 		findPreference("about_content").setSummary(
 				String.format(getString(R.string.about_content), BuildConfig.VERSION_NAME));
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,6 +30,16 @@
 		<item>@string/limitDpiModeAuto</item>
 		<item>@string/limitDpiModeOn</item>
 	</array>
+	<array name="extMouseLongPressModes">
+		<item>never</item>
+		<item>auto</item>
+		<item>always</item>
+	</array>
+	<array name="extMouseLongPressModeDescs">
+		<item>@string/extMouseLongPressNever</item>
+		<item>@string/extMouseLongPressAuto</item>
+		<item>@string/extMouseLongPressAlways</item>
+	</array>
 	<array name="chooserStyles">
 		<item>list</item>
 		<item>grid</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,10 +118,11 @@ If you don't want to grant it you can instead locate the file from within Puzzle
     <string name="chooserStyleGrid">Icons only (compact)</string>
     <string name="thisGame">This game</string>
     <string name="allGames">All games</string>
-    <string name="advancedSettings">Display and keyboard</string>
+    <string name="advancedSettings">Display and input</string>
     <string name="advancedSettingsSummary">Less frequently changed settings</string>
     <string name="displaySettings">Display</string>
     <string name="keyboardSettings">Keyboard</string>
+    <string name="mouseSettings">Mouse/Stylus</string>
     <string name="arrowKeysIn">Arrow keys in {0}</string>
     <string name="arrowKeysUnavailable">Arrow keys unavailable</string>
     <string name="arrowKeysUnavailableIn">Arrow keys unavailable in {0}</string>
@@ -146,6 +147,12 @@ If you don't want to grant it you can instead locate the file from within Puzzle
     <string name="undoRedoOnKeyboardSummary">Allows auto repeat (otherwise in action bar)</string>
     <string name="keyboardBorders">Show edges of keys</string>
     <string name="keyboardBordersSummary">Otherwise only symbols are shown</string>
+    <string name="extMouseLongPress">Use long-press with mouse/stylus</string>
+    <string name="extMouseLongPressNever">Never (only use devices with a right/alt button)</string>
+    <string name="extMouseLongPressAuto">Auto (disable when a right/alt click is detected)</string>
+    <string name="extMouseLongPressAlways">Always (same behavior as finger presses)</string>
+    <string name="extMouseBackKey">Support right mouse button</string>
+    <string name="extMouseBackKeySummary">"Override \"Back\" functionality of right button in puzzles"</string>
     <string name="bridgesShowH">"Show \"H\" in Bridges"</string>
     <string name="bridgesShowHSummary">"Undocumented \"solve from here\" action"</string>
     <string name="unequalShowH">"Show \"H\" in Unequal"</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -74,6 +74,17 @@
 									android:key="keyboardBorders"
 									android:defaultValue="false" />
 			</PreferenceCategory>
+			<PreferenceCategory android:title="@string/mouseSettings">
+				<ListPreference android:title="@string/extMouseLongPress"
+								android:key="extMouseLongPress"
+								android:entryValues="@array/extMouseLongPressModes"
+								android:entries="@array/extMouseLongPressModeDescs"
+								android:defaultValue="auto" />
+				<CheckBoxPreference android:title="@string/extMouseBackKey"
+									android:summary="@string/extMouseBackKeySummary"
+									android:key="extMouseBackKey"
+									android:defaultValue="true" />
+			</PreferenceCategory>
 		</PreferenceScreen>
 	</PreferenceCategory>
 


### PR DESCRIPTION
This adds full support for external mice; right-click now works on platforms that map it to the Back key, and the long-press restriction is removed (for mice that support right-click).  This makes the Android port function effectively identically to the upstream, when used with an external mouse.

In addition, the "no long press" changes should theoretically function for stylus as well, but I can't test that.
