### PR TITLE
Allow using S Pen button as 'right click' modifier

### DIFF
--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
@@ -144,7 +144,8 @@ public class GameView extends View
 						buttonState == MotionEvent.BUTTON_TERTIARY)  {
 					button = MIDDLE_BUTTON;
 				} else if ((meta & KeyEvent.META_SHIFT_ON) > 0  ||
-						buttonState == MotionEvent.BUTTON_SECONDARY) {
+						buttonState == MotionEvent.BUTTON_SECONDARY ||
+						buttonState == MotionEvent.BUTTON_STYLUS_PRIMARY) {
 					button = RIGHT_BUTTON;
 					hasRightMouse = true;
 				} else {
@@ -360,6 +361,9 @@ public class GameView extends View
 			}
 		});
 		ScaleGestureDetectorCompat.setQuickScaleEnabled(scaleDetector, false);
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+			scaleDetector.setStylusScaleEnabled(false);
+		}
 	}
 
 	void resetZoomForClear() {
@@ -453,6 +457,12 @@ public class GameView extends View
 	public boolean onTouchEvent(@NonNull MotionEvent event)
 	{
 		if (parent.currentBackend == null) return false;
+
+		int evAction = event.getAction();
+		if (isFromSource(event, SOURCE_STYLUS) && (evAction>=211) && (evAction<=213)) {
+			event.setAction(evAction-211);
+		}
+
 		boolean sdRet = checkPinchZoom(event);
 		boolean gdRet = gestureDetector.onTouchEvent(event);
 		return handleTouchEvent(event, sdRet || gdRet);


### PR DESCRIPTION
With this change, taps and strokes performed with the S Pen (Samsung stylus) while the S Pen's button is held, will act like right clicks (i.e., the L/R swap actions will be reversed).

Android's default in response to a stylus-held tap/drag is to treat it as an attempt to zoom; Line 364 prevents this. (The option to do so seems to only be available as of Android M; if anyone knows a way to do this in older versions please let me know, but for now I'll take some folks having access to this feature as better than nothing!)

Even with that disabled, for some reason, the Action codes returned with the stylus button held down are 211 higher than they are without it held down... I don't know why 211, I looked through the docs and couldn't find anything that corresponded to it. Subtracting 211 was the only way I could find to get the strokes to still be acknowledged; if anyone knows a better way to handle this (or even an SDK-provided constant to put instead of the hard-coded number) I'd appreciate it, but for now this seems to work fine for me. (I'm testing for the Action code rather than the button state because the codes actually stay high when the button is released mid-stroke, which was causing strokes to get stuck incomplete if a user didn't keep the button held, until I changed the test to look at the codes instead.)

One other thing to note is, my installation of Android Studio did some kind of auto-update on the project that touched all kinds of configuration files; I'm not committing those here, but as a result, I can't actually say first-hand whether or not this will compile/run correctly in its original configuration? If there's a better way of handling this please let me know; this is actually my first time doing Android development, so I apologize if I'm missing anything obvious or ignoring any best practices! I appreciate any input.