### PR TITLE
don't reset zoom between games

### DIFF
--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
@@ -900,7 +900,7 @@ public class GamePlay extends ActivityWithLoadButton implements OnSharedPreferen
 			}
 		}
 		dismissProgress();
-		gameView.rebuildBitmap(false);
+		gameView.rebuildBitmap(prefs.getBoolean(PrefsConstants.RESET_ZOOM_KEY, PrefsConstants.RESET_ZOOM_DEFAULT));
 		if (menu != null) onPrepareOptionsMenu(menu);
 		save();
 	}

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GamePlay.java
@@ -864,7 +864,6 @@ public class GamePlay extends ActivityWithLoadButton implements OnSharedPreferen
 
 		currentBackend = startingBackend;
 		refreshColours();
-		gameView.resetZoomForClear();
 		gameView.clear();
 		applyUndoRedoKbd();
 		gameView.keysHandled = 0;
@@ -901,7 +900,7 @@ public class GamePlay extends ActivityWithLoadButton implements OnSharedPreferen
 			}
 		}
 		dismissProgress();
-		gameView.rebuildBitmap();
+		gameView.rebuildBitmap(false);
 		if (menu != null) onPrepareOptionsMenu(menu);
 		save();
 	}
@@ -1395,7 +1394,7 @@ public class GamePlay extends ActivityWithLoadButton implements OnSharedPreferen
 				"off".equals(pref) ? GameView.LimitDPIMode.LIMIT_OFF :
 						GameView.LimitDPIMode.LIMIT_ON;
 		if (alreadyStarted) {
-			gameView.rebuildBitmap();
+			gameView.rebuildBitmap(true);
 		}
 	}
 

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
@@ -702,7 +702,7 @@ public class GameView extends View implements GameEngine.ViewCallbacks
 		if (lastDrag != null) revertDragInProgress(lastDrag);
 		w = Math.max(1, viewW); h = Math.max(1, viewH);
 		Log.d("GameView", "onSizeChanged: " + w + ", " + h);
-		rebuildBitmap();
+		rebuildBitmap(true);
 		if (isInEditMode()) {
 			// Draw a little placeholder to aid UI editing
 			final Drawable d = ContextCompat.getDrawable(getContext(), R.drawable.net);
@@ -714,7 +714,7 @@ public class GameView extends View implements GameEngine.ViewCallbacks
 		}
 	}
 
-	void rebuildBitmap() {
+	void rebuildBitmap(boolean resetZoomMatrix) {
 		switch (limitDpi) {
 			case LIMIT_OFF:
 				density = 1.f;
@@ -742,7 +742,9 @@ public class GameView extends View implements GameEngine.ViewCallbacks
 		clear();
 		canvas = new Canvas(bitmap);
 		canvasRestoreJustAfterCreation = canvas.save();
-		resetZoomForClear();
+		if(resetZoomMatrix) {
+			resetZoomForClear();
+		}
 		redrawForInitOrZoomChange();
 	}
 

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/GameView.java
@@ -742,7 +742,7 @@ public class GameView extends View implements GameEngine.ViewCallbacks
 		clear();
 		canvas = new Canvas(bitmap);
 		canvasRestoreJustAfterCreation = canvas.save();
-		if(resetZoomMatrix) {
+		if (resetZoomMatrix) {
 			resetZoomForClear();
 		}
 		redrawForInitOrZoomChange();

--- a/app/src/main/java/name/boyle/chris/sgtpuzzles/PrefsConstants.java
+++ b/app/src/main/java/name/boyle/chris/sgtpuzzles/PrefsConstants.java
@@ -20,6 +20,8 @@ abstract class PrefsConstants {
     static final String UNEQUAL_SHOW_H_KEY = "unequalShowH";
     static final String LATIN_SHOW_M_KEY = "latinShowM";
     static final String FULLSCREEN_KEY = "fullscreen";
+    static final String RESET_ZOOM_KEY = "resetZoom";
+    static final boolean RESET_ZOOM_DEFAULT = true;
     static final String STAY_AWAKE_KEY = "stayAwake";
     static final String UNDO_REDO_KBD_KEY = "undoRedoOnKeyboard";
     static final boolean UNDO_REDO_KBD_DEFAULT = true;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,8 @@ Version %s"</string>
     <string name="arrowKeysUnavailableIn">Arrow keys unavailable in {0}</string>
     <string name="fullscreen">Full screen</string>
     <string name="fullscreenSummary">Hide notifications</string>
+    <string name="resetZoom">Reset zoom</string>
+    <string name="resetZoomSummary">Reset zoom between games</string>
     <string name="stayAwake">Stay awake</string>
     <string name="stayAwakeSummary">Keep screen on while in the foreground</string>
     <string name="autoOrient">Match game orientation to screen</string>

--- a/app/src/main/res/xml/prefs_display_and_input.xml
+++ b/app/src/main/res/xml/prefs_display_and_input.xml
@@ -32,6 +32,13 @@
 			app:iconSpaceReserved="false" />
 
 		<SwitchPreferenceCompat
+			android:defaultValue="true"
+			android:key="resetZoom"
+			android:summary="@string/resetZoomSummary"
+			android:title="@string/resetZoom"
+			app:iconSpaceReserved="false" />
+
+		<SwitchPreferenceCompat
 			android:defaultValue="false"
 			android:key="stayAwake"
 			android:summary="@string/stayAwakeSummary"


### PR DESCRIPTION
reason for change: I like to choose width, height and then zoom in a way to best utilize screen real estate. But currently, after starting a new game it resets zoom, and I have to re-zoom.

I play in a way where I finish a game every few minutes, so I have to re-zoom quite often.

This change keeps the zoom constant.