### PR TITLE
Implement long press timeout setting

### DIFF
--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
@@ -34,6 +34,7 @@ import android.view.MenuItem
 import android.view.MenuItem.SHOW_AS_ACTION_ALWAYS
 import android.view.MenuItem.SHOW_AS_ACTION_WITH_TEXT
 import android.view.View
+import android.view.ViewConfiguration
 import android.view.WindowManager
 import android.view.WindowManager.BadTokenException
 import android.widget.Button
@@ -102,6 +103,7 @@ import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LAST_PARAMS_PREFIX
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LATIN_M_UNDO_SEEN
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LATIN_SHOW_M_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LIMIT_DPI_KEY
+import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LONG_PRESS_TIMEOUT
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.MOUSE_BACK_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.MOUSE_LONG_PRESS_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.ORIENTATION_KEY
@@ -366,6 +368,7 @@ class GamePlay : ActivityWithLoadButton(), OnSharedPreferenceChangeListener, Gam
         gameView.requestFocus()
         _wasNight = isNight(resources.configuration)
         applyLimitDPI(false)
+        applyLongPressTimeout()
         applyMouseLongPress()
         applyMouseBackKey()
         window.setBackgroundDrawable(null)
@@ -1324,8 +1327,20 @@ class GamePlay : ActivityWithLoadButton(), OnSharedPreferenceChangeListener, Gam
             ORIENTATION_KEY -> applyOrientation()
             UNDO_REDO_KBD_KEY -> applyUndoRedoKbd()
             BRIDGES_SHOW_H_KEY, UNEQUAL_SHOW_H_KEY, LATIN_SHOW_M_KEY -> applyKeyboardFilters()
+            LONG_PRESS_TIMEOUT -> applyLongPressTimeout()
             MOUSE_LONG_PRESS_KEY -> applyMouseLongPress()
             MOUSE_BACK_KEY -> applyMouseBackKey()
+        }
+    }
+
+    private fun applyLongPressTimeout() {
+        gameView.longPressTimeout = when (prefs.getString(LONG_PRESS_TIMEOUT, "system")) {
+            "system" -> ViewConfiguration.getLongPressTimeout()
+            "very short" -> 150
+            "short" -> 300
+            "normal" -> 500
+            "long" -> 1000
+            else -> ViewConfiguration.getLongPressTimeout()
         }
     }
 

--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GameView.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GameView.kt
@@ -100,7 +100,7 @@ class GameView(context: Context, attrs: AttributeSet?) : View(context, attrs), V
     var h = 0
     var wDip = 0
     var hDip = 0
-    private val longPressTimeout = ViewConfiguration.getLongPressTimeout()
+    var longPressTimeout = ViewConfiguration.getLongPressTimeout()
     private var hardwareKeys = ""
     var night = false
     var hasRightMouse = false

--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/config/PrefsConstants.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/config/PrefsConstants.kt
@@ -22,6 +22,7 @@ object PrefsConstants {
     const val STAY_AWAKE_KEY = "stayAwake"
     const val UNDO_REDO_KBD_KEY = "undoRedoOnKeyboard"
     const val UNDO_REDO_KBD_DEFAULT = true
+    const val LONG_PRESS_TIMEOUT = "longPressTimeout"
     const val MOUSE_LONG_PRESS_KEY = "extMouseLongPress"
     const val MOUSE_BACK_KEY = "extMouseBackKey"
     //const val PATTERN_SHOW_LENGTHS_KEY = "patternShowLengths"

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -35,6 +35,20 @@
 		<item>@string/limitDpiModeAuto</item>
 		<item>@string/limitDpiModeOn</item>
 	</array>
+	<array name="longPressTimeout">
+		<item>system</item>
+		<item>very short</item>
+		<item>short</item>
+		<item>medium</item>
+		<item>long</item>
+	</array>
+	<array name="longPressTimeoutDescs">
+		<item>@string/longPressTimeoutSystem</item>
+		<item>@string/longPressTimeoutVeryShort</item>
+		<item>@string/longPressTimeoutShort</item>
+		<item>@string/longPressTimeoutMedium</item>
+		<item>@string/longPressTimeoutLong</item>
+	</array>
 	<array name="extMouseLongPressModes">
 		<item>never</item>
 		<item>auto</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,6 +142,12 @@ Version %s"</string>
     <string name="undoRedoOnKeyboardSummary">Allows auto repeat (otherwise in action bar)</string>
     <string name="keyboardBorders">Show edges of keys</string>
     <string name="keyboardBordersSummary">Otherwise only symbols are shown</string>
+    <string name="longPressTimeout">Long-press timeout</string>
+    <string name="longPressTimeoutSystem">Use system setting</string>
+    <string name="longPressTimeoutVeryShort">Very Short (150 ms)</string>
+    <string name="longPressTimeoutShort">Short (300 ms)</string>
+    <string name="longPressTimeoutMedium">Medium (500 ms)</string>
+    <string name="longPressTimeoutLong">Long (1000 ms)</string>
     <string name="extMouseLongPress">Use long-press with mouse/stylus</string>
     <string name="extMouseLongPressNever">Never (only use devices with a right/alt button)</string>
     <string name="extMouseLongPressAuto">Auto (disable when a right/alt click is detected)</string>

--- a/app/src/main/res/xml/prefs_display_and_input.xml
+++ b/app/src/main/res/xml/prefs_display_and_input.xml
@@ -81,6 +81,15 @@
 		app:iconSpaceReserved="false">
 
 		<ListPreference
+			android:defaultValue="system"
+			android:entries="@array/longPressTimeoutDescs"
+			android:entryValues="@array/longPressTimeout"
+			android:key="longPressTimeout"
+			android:title="@string/longPressTimeout"
+			app:iconSpaceReserved="false"
+			app:useSimpleSummaryProvider="true" />
+
+		<ListPreference
 			android:defaultValue="auto"
 			android:entries="@array/extMouseLongPressModeDescs"
 			android:entryValues="@array/extMouseLongPressModes"


### PR DESCRIPTION
Adds a setting to override the long press timeout system setting.

I found that even the shortest system setting on my Galaxy S10 (300 ms) is longer than I'd prefer for some puzzles like Loopy, Palisade, and Range.

The numbers are a bit arbitrary:
* Very short (150 ms)
* Short (300 ms)
* Medium (500 ms)
* Long (1000 ms)

I can change the numbers or change this into a free input if that would be better, but I think the current numbers should be reasonably good for most cases.