### PR TITLE
New setting to allow one-finger pan in Minesweeper

### DIFF
--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
@@ -111,6 +111,7 @@ import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LATIN_M_UNDO_SEEN
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LATIN_SHOW_M_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LIMIT_DPI_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.LONG_PRESS_TIMEOUT
+import name.boyle.chris.sgtpuzzles.config.PrefsConstants.MINES_ONE_FINGER_PAN_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.MOUSE_BACK_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.MOUSE_LONG_PRESS_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.ORIENTATION_KEY
@@ -1357,6 +1358,7 @@ class GamePlay : ActivityWithLoadButton(), OnSharedPreferenceChangeListener, Gam
             LONG_PRESS_TIMEOUT -> applyLongPressTimeout()
             MOUSE_LONG_PRESS_KEY -> applyMouseLongPress()
             MOUSE_BACK_KEY -> applyMouseBackKey()
+            MINES_ONE_FINGER_PAN_KEY -> gameViewResized()
         }
     }
 

--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GameView.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GameView.kt
@@ -61,11 +61,14 @@ import androidx.annotation.ColorRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.view.MotionEventCompat
+import androidx.preference.PreferenceManager
+import name.boyle.chris.sgtpuzzles.config.PrefsConstants.MINES_ONE_FINGER_PAN_KEY
 import name.boyle.chris.sgtpuzzles.GameView.LimitDPIMode.LIMIT_AUTO
 import name.boyle.chris.sgtpuzzles.GameView.LimitDPIMode.LIMIT_OFF
 import name.boyle.chris.sgtpuzzles.GameView.LimitDPIMode.LIMIT_ON
 import name.boyle.chris.sgtpuzzles.backend.BackendName
 import name.boyle.chris.sgtpuzzles.backend.GameEngine.ViewCallbacks
+import name.boyle.chris.sgtpuzzles.backend.MINES
 import name.boyle.chris.sgtpuzzles.backend.UsedByJNI
 import kotlin.math.abs
 import kotlin.math.floor
@@ -510,7 +513,11 @@ class GameView(context: Context, attrs: AttributeSet?) : View(context, attrs), V
                     distanceY: Float
                 ): Boolean {
                     // 2nd clause is 2 fingers a constant distance apart
-                    if (isScaleInProgress || event.pointerCount > 1) {
+                    val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+                    val minesOneFingerPan = prefs.getBoolean(MINES_ONE_FINGER_PAN_KEY, false)
+
+                    if (isScaleInProgress || event.pointerCount > 1 ||
+                        (parent.currentBackend == MINES && event.pointerCount == 1 && minesOneFingerPan)) {
                         revertDragInProgress(event.point)
                         if (touchState == TouchState.WAITING_LONG_PRESS) {
                             parent.handler.removeCallbacks(sendLongPress)

--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/config/PrefsConstants.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/config/PrefsConstants.kt
@@ -42,4 +42,5 @@ object PrefsConstants {
     const val NIGHT_MODE_KEY = "nightMode"
     const val SEEN_NIGHT_MODE = "seenNightMode"
     const val SEEN_NIGHT_MODE_SETTING = "seenNightModeSetting"
+    const val MINES_ONE_FINGER_PAN_KEY = "minesOneFingerPan"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,8 @@ Version %s"</string>
     <string name="extMouseLongPressAlways">Always (same behavior as finger presses)</string>
     <string name="extMouseBackKey">Support right mouse button</string>
     <string name="extMouseBackKeySummary">Override “Back” functionality of right button in puzzles</string>
+    <string name="minesOneFingerPan">One-finger movement in Mines</string>
+    <string name="minesOneFingerPanSummary">Allow one-finger panning in Minesweeper</string>
     <string name="bridgesShowH">Show “H” in Bridges"</string>
     <string name="bridgesShowHSummary">Undocumented “solve from here” action</string>
     <string name="unequalShowH">Show “H” in Unequal</string>

--- a/app/src/main/res/xml/prefs_display_and_input.xml
+++ b/app/src/main/res/xml/prefs_display_and_input.xml
@@ -97,6 +97,13 @@
 			android:title="@string/extMouseBackKey"
 			app:iconSpaceReserved="false" />
 
+		<SwitchPreferenceCompat
+			android:defaultValue="false"
+			android:key="minesOneFingerPan"
+			android:summary="@string/minesOneFingerPanSummary"
+			android:title="@string/minesOneFingerPan"
+			app:iconSpaceReserved="false" />
+
 	</PreferenceCategory>
 
 	<!-- spacer for edge-to-edge, ensuring the last real preference above can be scrolled into view -->


### PR DESCRIPTION
New setting to allow movement of the board with one finger instead of two in Minesweeper

<img width="605" height="1342" alt="image" src="https://github.com/user-attachments/assets/b7d3f992-f330-4cd5-bca8-0d0d975c8429" />
