### PR TITLE
Add preference to keep buttons on screen (issue #563)

### DIFF
--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
@@ -1493,7 +1493,7 @@ class GamePlay : ActivityWithLoadButton(), OnSharedPreferenceChangeListener, Gam
                 || prefs.getBoolean(ALWAYS_SHOW_KEYBOARD_KEY, false)
         }
 
-        private val isProbablyEmul  ator: Boolean
+        private val isProbablyEmulator: Boolean
             get() = Build.MODEL.startsWith("sdk_") || Build.MODEL.startsWith("Android SDK")
 
         fun getArrowKeysPrefName(whichBackend: BackendName?, c: Configuration): String =

--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/GamePlay.kt
@@ -98,6 +98,7 @@ import name.boyle.chris.sgtpuzzles.buttons.SEEN_SWAP_L_R_TOAST
 import name.boyle.chris.sgtpuzzles.buttons.SWAP_L_R_KEY
 import name.boyle.chris.sgtpuzzles.config.ConfigBuilder
 import name.boyle.chris.sgtpuzzles.config.ConfigBuilder.Event.CFG_SETTINGS
+import name.boyle.chris.sgtpuzzles.config.PrefsConstants.ALWAYS_SHOW_KEYBOARD_KEY
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.ARROW_KEYS_KEY_SUFFIX
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.AUTO_ORIENT
 import name.boyle.chris.sgtpuzzles.config.PrefsConstants.AUTO_ORIENT_DEFAULT
@@ -1116,7 +1117,8 @@ class GamePlay : ActivityWithLoadButton(), OnSharedPreferenceChangeListener, Gam
             lastArrowMode === ArrowMode.ARROWS_LEFT_RIGHT_CLICK || whichBackend === PALISADE || whichBackend === NET
         val maybeSwapLRKey = if (shouldHaveSwap) SWAP_L_R_KEY.toString() else ""
         val newKeys =
-            if (shouldShowFullSoftKeyboard(c)) filterKeys(newArrowMode) + maybeSwapLRKey + maybeUndoRedo else maybeSwapLRKey + maybeUndoRedo
+            if (shouldShowFullSoftKeyboard(c, prefs)) filterKeys(newArrowMode) + maybeSwapLRKey + maybeUndoRedo
+            else maybeSwapLRKey + maybeUndoRedo
         val swap = whichBackend?.getSwapLR(this) ?: false
         if (whichBackend?.swapLRNatively != true) swapLROn = swap
         with (buttons) {
@@ -1482,14 +1484,16 @@ class GamePlay : ActivityWithLoadButton(), OnSharedPreferenceChangeListener, Gam
         private const val PREVENT_BACK_AFTER_KEY_PRESS_MILLIS = 600
 
         /** Whether to show data-entry keys, as opposed to undo/redo/swap-L-R which are always shown.
-         * We show data-entry if we either don't have a real hardware keyboard (we usually don't),
-         * or we're on the Android SDK's emulator, which has the host's keyboard, but showing the full
-         * keyboard is useful for UI development and screenshots.  */
-        private fun shouldShowFullSoftKeyboard(c: Configuration): Boolean {
+         * We show data-entry if we don't have a real hardware keyboard (we usually don't), or we're
+         * on the Android SDK's emulator, which has the host's keyboard (but showing the full keyboard
+         * is useful for UI development and screenshots), or the user has activated the "Always show
+         * keyboard" preference.  */
+        private fun shouldShowFullSoftKeyboard(c: Configuration, prefs: SharedPreferences): Boolean {
             return c.hardKeyboardHidden != HARDKEYBOARDHIDDEN_NO || c.keyboard == KEYBOARD_NOKEYS || isProbablyEmulator
+                || prefs.getBoolean(ALWAYS_SHOW_KEYBOARD_KEY, false)
         }
 
-        private val isProbablyEmulator: Boolean
+        private val isProbablyEmul  ator: Boolean
             get() = Build.MODEL.startsWith("sdk_") || Build.MODEL.startsWith("Android SDK")
 
         fun getArrowKeysPrefName(whichBackend: BackendName?, c: Configuration): String =

--- a/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/config/PrefsConstants.kt
+++ b/app/src/main/kotlin/name/boyle/chris/sgtpuzzles/config/PrefsConstants.kt
@@ -14,6 +14,7 @@ object PrefsConstants {
     const val ORIENTATION_KEY = "orientation"
     const val ARROW_KEYS_KEY_SUFFIX = "ArrowKeys"
     const val LIMIT_DPI_KEY = "limitDpi"
+    const val ALWAYS_SHOW_KEYBOARD_KEY = "alwaysShowKeyboard"
     const val KEYBOARD_BORDERS_KEY = "keyboardBorders"
     const val BRIDGES_SHOW_H_KEY = "bridgesShowH"
     const val UNEQUAL_SHOW_H_KEY = "unequalShowH"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,8 @@ Version %s"</string>
     <string name="limitDpiModeOff">Never (1 pixel = 1 pixel)</string>
     <string name="limitDpiModeAuto">Thinner as puzzle size increases (recommended)</string>
     <string name="limitDpiModeOn">Always 160dpi (not recommended)</string>
+    <string name="alwaysShowKeyboard">Always show keyboard</string>
+    <string name="alwaysShowKeyboardSummary">Even when a hardware keyboard is available</string>
     <string name="undoRedoOnKeyboard">Include Undo/Redo</string>
     <string name="undoRedoOnKeyboardSummary">Allows auto repeat (otherwise in action bar)</string>
     <string name="keyboardBorders">Show edges of keys</string>

--- a/app/src/main/res/xml/prefs_display_and_input.xml
+++ b/app/src/main/res/xml/prefs_display_and_input.xml
@@ -61,6 +61,13 @@
 		app:iconSpaceReserved="false">
 
 		<SwitchPreferenceCompat
+			android:defaultValue="false"
+			android:key="alwaysShowKeyboard"
+			android:summary="@string/alwaysShowKeyboardSummary"
+			android:title="@string/alwaysShowKeyboard"
+			app:iconSpaceReserved="false" />
+
+		<SwitchPreferenceCompat
 			android:defaultValue="true"
 			android:key="undoRedoOnKeyboard"
 			android:summary="@string/undoRedoOnKeyboardSummary"


### PR DESCRIPTION
My current smartphone is a Purism Librem 5 with PureOS (a non-Android Linux). Its app store contains Waydroid - an environment for running Android apps. I tested sgtpuzzles under Waydroid and data-entry keys were missing. Checking issues on Github turned up #563 which matched the symptoms. To confirm my suspicion, I built the apk with `shouldShowFullSoftKeyboard()` always returning `true`. Sure enough, the keys appeared.

My options were:
1. Configure Waydroid to send `KEYBOARD_NOKEYS`
2. Find out what Waydroid sends as `Build.MODEL` and add an appropriate prefix to `isProbablyEmulator`
3. Implement #563

I decided to add the preference since it would help in other scenarios as well (as described in the issue). I called the preference "Always show keyboard" and placed it under "Display and input" / "Keyboard". I hope that's OK.